### PR TITLE
fix: cypress staff skeleton tests

### DIFF
--- a/cypress/utils/modules/StaffPage/StaffDetailsTestFunctions.ts
+++ b/cypress/utils/modules/StaffPage/StaffDetailsTestFunctions.ts
@@ -72,8 +72,9 @@ export class StaffDetailsTestFunctions {
       request.responseTimeout = 5000;
     });
     this.getSkeletonRow().should('exist');
+    this.getSkeletonRow().should('have.length', 3);
     this.getSkeletonTile().should('exist');
-    this.getDetailsTile().should('have.length', 4);
+    this.getSkeletonTile().should('have.length', 2);
   };
 
   // error handling will be improved in the future


### PR DESCRIPTION
## Description
skeleton tiles do not have expected value


## Clickup Ticket
[https://sharing.clickup.com/26492745/t/h/862kngv1d/JB8RXDH12Q8W4XD](url)

